### PR TITLE
Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # CHDconvert
-Converts a directory containing ".gz" and ".7z" files into a directory containing ".chd" files, usually for purposes of console emulation.
+Converts a directory containing ".gz", ".7z" and ".zip" files into a directory containing ".chd" files, usually for purposes of console emulation.
 
 # Requirements (Included with Linux/Mac)
 [`Python`](https://www.python.org/downloads/)\

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ pip install -r requirements.txt
 ```
 
 # Linux Additionals
-Use your distro's package/download manager to get mame-tools.
+Some Linux distributions can give you chdman via aptitude with the mame-tools package.
+Use your distro's package/download manager to get mame-tools (for chdman).
 eg. Debian-variants using apt
 ```
 sudo apt install mame-tools

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ Install requirements
 pip install -r requirements.txt
 ```
 
+# Linux Additionals
+Use your distro's package/download manager to get mame-tools.
+eg. Debian-variants using apt
+```
+sudo apt install mame-tools
+```
 
 
 # Usage

--- a/README.md
+++ b/README.md
@@ -48,25 +48,25 @@ Examples:
 
 - Simply run it, and provide the folder path when it asks for it.
   ```
-  python.exe .\chdconvert.py
+  python .\chdconvert.py
   ```
   Converts every .7z file in given path to chd. Extracts first, outputs to folder name + "_tmp", then converts and output to folder     name + "_out"
   
 - Provide a folder path as an arg
   ```
-  python.exe .\chdconvert.py C:\Where\the\7zip\files\live
+  python .\chdconvert.py C:\Where\the\7zip\files\live
   ```
   Does the same as the above
 
 - Provide the delete arg ("-d" or "--delete")
   ```
-  python.exe .\chdconvert.py C:\Where\the\7zip\files\live --delete
+  python .\chdconvert.py C:\Where\the\7zip\files\live --delete
   ```
   Same as above, except it deletes the intermediary "folder_tmp" directory
 
 - Provide the replace arg ("-r" or "--replace")
   ```
-  python.exe .\chdconvert.py C:\Where\the\7zip\files\live --replace
+  python .\chdconvert.py C:\Where\the\7zip\files\live --replace
   ```
   Replaces the 7zip file, deleting the original as well as the intermediary files in "folder_tmp"
 

--- a/chdconvert.py
+++ b/chdconvert.py
@@ -6,12 +6,15 @@ import shutil
 
 input_dir = input("Input Dir:\n") if len(sys.argv) < 2 else sys.argv[1]
 tmp_dir = input_dir + "_tmp"
-chdman = os.path.join(os.path.dirname(__file__), 'chdman.exe')
+if os.name == 'nt':
+    chdman = os.path.join(os.path.dirname(__file__), 'chdman.exe')
+else:
+    chdman = 'chdman'
 operator = sys.argv[2] if (len(sys.argv) == 3 and sys.argv[2] in ["-d", "--delete", "-r", "--replace"]) else None
 error_log_file = "skipped_archives.txt"
 
 # Updated to handle both gz and 7z files
-incoming_files = [f for f in os.listdir(input_dir) if f.split(".")[-1] in ["gz", "7z"]]  
+incoming_files = [f for f in os.listdir(input_dir) if f.split(".")[-1] in ["gz", "7z", "zip"]]  # Support additional archives, eg. zip
 for x in incoming_files:
     try:
         if not os.path.exists(tmp_dir):
@@ -39,7 +42,7 @@ for x in incoming_files:
             out_path = f'"{os.path.join(output_dir, archive_name)}.chd"' # Use archive name for CHD file  
             cmd = " ".join([chdman, "createcd", "-f", "-i", f'\"{os.path.join(tmp_dir, out, i)}\"', "-o", out_path])
             print("COMMAND: " + cmd)
-            subprocess.call(cmd)
+            subprocess.call(cmd, shell=True) # Linux: by default subprocess.call doesn't use a shell to run commands
             print(f"{i} has been converted to chd.")
 
         if operator:


### PR DESCRIPTION
Some amendments to get it working on linux.

Removing the executable file extension from the usage examples can make it usable for both linux & windows (since windows executable files can run without explicitly specifying the extension). Linux users should be able to give paths in linux-path-format-conventions.

Btw: python/git isn't always installed under linux as it depends on the linux distro. Again, this is easy to install under linux via their package manager: sudo apt install python git



